### PR TITLE
Make auto-closing swiped-open rows more declarative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ web-report/
 # React Native ?
 android/
 ios/
+
+# VS Code workspace settings
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,3 @@ web-report/
 # React Native ?
 android/
 ios/
-
-# VS Code workspace settings
-.vscode/

--- a/src/components/SearchView/DeletableRow.tsx
+++ b/src/components/SearchView/DeletableRow.tsx
@@ -1,29 +1,35 @@
 import React, { Component } from 'react';
-import { Animated, StyleSheet, Text, View, I18nManager, Platform } from 'react-native';
+import {
+  Animated,
+  StyleSheet,
+  Text,
+  View,
+  I18nManager,
+  Platform,
+} from 'react-native';
 
 import { RectButton } from 'react-native-gesture-handler';
 import Swipeable from 'react-native-gesture-handler/Swipeable';
 
 import Icon from 'react-native-vector-icons/MaterialIcons';
 
-
 type Props = {
-  onDelete: () => void,
-  onSwipeableOpen: (ref: React.RefObject<Swipeable>) => void,
+  onDelete: () => void;
+  onSwipeableOpen: (ref: React.RefObject<Swipeable>) => void;
+  onSwipeableClose: () => void;
 };
 export default class DeleteableRow extends Component<Props> {
   _swipeableRow: React.RefObject<Swipeable> = React.createRef();
 
-  renderRightAction = progress => {
+  renderRightAction = (progress) => {
     const trans = progress.interpolate({
       inputRange: [0, 1],
       outputRange: [64, 0],
+      extrapolate: 'clamp',
     });
     return (
       <Animated.View style={{ flex: 1, transform: [{ translateX: trans }] }}>
-        <RectButton
-          style={styles.deleteAction}
-          onPress={this.handlePress}>
+        <RectButton style={styles.deleteAction} onPress={this.handlePress}>
           {Platform.OS === 'ios' ? (
             <Text style={styles.actionText}>Delete</Text>
           ) : (
@@ -38,12 +44,13 @@ export default class DeleteableRow extends Component<Props> {
       </Animated.View>
     );
   };
-  renderRightActions = progress => (
+  renderRightActions = (progress) => (
     <View
       style={{
         width: 64,
         flexDirection: I18nManager.isRTL ? 'row-reverse' : 'row',
-      }}>
+      }}
+    >
       {this.renderRightAction(progress)}
     </View>
   );
@@ -64,7 +71,9 @@ export default class DeleteableRow extends Component<Props> {
         rightThreshold={40}
         renderRightActions={this.renderRightActions}
         enableTrackpadTwoFingerGesture={true}
-        onSwipeableOpen={this.handleSwipeableOpen}>
+        onSwipeableOpen={this.handleSwipeableOpen}
+        onSwipeableClose={this.props.onSwipeableClose}
+      >
         {children}
       </Swipeable>
     );
@@ -86,6 +95,6 @@ const styles = StyleSheet.create({
   },
   actionIcon: {
     width: 30,
-    marginHorizontal: 10
+    marginHorizontal: 10,
   },
 });

--- a/src/components/SearchView/SearchView.tsx
+++ b/src/components/SearchView/SearchView.tsx
@@ -5,9 +5,10 @@ import {
   FlatList,
   Platform,
   Pressable,
+  Keyboard,
   Text,
   View,
-  useWindowDimensions
+  useWindowDimensions,
 } from 'react-native';
 import { SearchBar } from 'react-native-elements';
 import Constants from 'expo-constants';
@@ -16,28 +17,21 @@ import styles, { resultItemHeight, separatorHeight } from './styles';
 import DeletableRow from './DeletableRow';
 import { RectButton } from 'react-native-gesture-handler';
 
-
 type Props = {
-  query: string,
-  results: string[],
-  placeholder: string,
-  onChangeQuery: (query: string) => void,
-  onCancel: () => void,
-  onSubmit: (query: string) => void,
-  onDelete: (siteTag: string) => void,
+  query: string;
+  results: string[];
+  placeholder: string;
+  onChangeQuery: (query: string) => void;
+  onCancel: () => void;
+  onSubmit: (query: string) => void;
+  onDelete: (siteTag: string) => void;
 };
 
 const BLANK = {};
 
 export default function SearchView(props: Props) {
-  const {
-    query,
-    placeholder,
-    onChangeQuery,
-    onCancel,
-    onSubmit,
-    onDelete,
-  } = props;
+  const { query, placeholder, onChangeQuery, onCancel, onSubmit, onDelete } =
+    props;
 
   const paddedResults = [...props.results];
   const queryNotInResults = query && !props.results.includes(query);
@@ -63,23 +57,29 @@ export default function SearchView(props: Props) {
   // the results list look like a ruled page, with lines going all
   // the way down to the top edge of the onscreen keyboard
   const windowHeight = useWindowDimensions().height;
-  const availableHeightForResults = (windowHeight - resultListTopY) - keyboardHeight;
-  const numResultsThatCover = Math.ceil(availableHeightForResults / resultItemHeight);
+  const availableHeightForResults =
+    windowHeight - resultListTopY - keyboardHeight;
+  const numResultsThatCover = Math.ceil(
+    availableHeightForResults / resultItemHeight
+  );
   const gap = numResultsThatCover - paddedResults.length;
   if (gap > 0) {
     paddedResults.push(...new Array(gap).fill(BLANK));
   }
 
   // Keep track of which item in the list is being swiped on
-  const [ activeItemRef, setActiveItemRef ]:
-    [Swipeable, (ref: Swipeable) => void] = React.useState(null);
-  const [ activeItemIndex, setActiveItemIndex ] = React.useState(null);
+  const [activeItemRef, setActiveItemRef]: [
+    Swipeable,
+    (ref: Swipeable) => void
+  ] = React.useState(null);
+  const [activeItemIndex, setActiveItemIndex] = React.useState(null);
 
   const onSwipeOpen = (ref, index) => {
     setActiveItemIndex(index);
     setActiveItemRef(ref);
   };
-  const onPressIn = index => {
+  const onPressIn = (index) => {
+    // Keyboard.dismiss();
     if (activeItemRef && index !== activeItemIndex) {
       activeItemRef.close();
     }
@@ -106,13 +106,19 @@ export default function SearchView(props: Props) {
         showCancel={true}
       />
       <Pressable
-        style={[styles.resultListContainer, {
-          paddingBottom: Platform.OS === 'ios' ? keyboardHeight : 0,
-        }]}
-        onLayout={event => {
+        style={[
+          styles.resultListContainer,
+          {
+            paddingBottom: Platform.OS === 'ios' ? keyboardHeight : 0,
+          },
+        ]}
+        onLayout={(event) => {
           setResultListTopY(event.nativeEvent.layout.y);
         }}
-        onPressIn={() => searchBarRef.current?.blur()}
+        onPressIn={() => {
+          console.log('Enclosing Pressable.onPressIn');
+          searchBarRef.current?.blur();
+        }}
       >
         <FlatList
           style={styles.resultList}
@@ -123,13 +129,12 @@ export default function SearchView(props: Props) {
             length: resultItemHeight,
             offset: (resultItemHeight + separatorHeight) * index,
           })}
-          keyExtractor={(item, index) => item === BLANK ?
-            String(index)
-            : '$' + item // add character in case `item` is a numeral
+          keyExtractor={
+            (item, index) => (item === BLANK ? String(index) : '$' + item) // add character in case `item` is a numeral
           }
           ref={resultListRef}
           ItemSeparatorComponent={Separator}
-          renderItem={({ item, index }) =>
+          renderItem={({ item, index }) => (
             <Item
               item={item}
               index={index}
@@ -140,27 +145,26 @@ export default function SearchView(props: Props) {
               onSwipeOpen={onSwipeOpen}
               onPressIn={onPressIn}
             />
-          }
+          )}
+          keyboardShouldPersistTaps="handled"
         />
       </Pressable>
     </View>
   );
-};
-
+}
 
 function Separator() {
   return <View style={styles.separator} />;
 }
 
-
 type ItemProps = {
-  item: string,
-  index: number,
-  isNew: boolean,
-  onSubmit: (item: string) => void,
-  onDelete: (item: string) => void,
-  onSwipeOpen: (ref: Swipeable, index: number) => void,
-  onPressIn: (index: number) => void,
+  item: string;
+  index: number;
+  isNew: boolean;
+  onSubmit: (item: string) => void;
+  onDelete: (item: string) => void;
+  onSwipeOpen: (ref: Swipeable, index: number) => void;
+  onPressIn: (index: number) => void;
 };
 class Item extends React.PureComponent<ItemProps> {
   deleteItem = () => {
@@ -200,35 +204,26 @@ class Item extends React.PureComponent<ItemProps> {
       inner = (
         <DeletableRow
           onDelete={this.deleteItem}
-          onSwipeableOpen={this.markActive}>
+          onSwipeableOpen={this.markActive}
+        >
           {this.renderSubmittable()}
         </DeletableRow>
       );
     }
 
-    return (
-      <Pressable
-        onPressIn={this.handlePressIn}>
-        {inner}
-      </Pressable>
-    );
+    return <Pressable onPressIn={this.handlePressIn}>{inner}</Pressable>;
   }
 
   renderSubmittable() {
     const { item } = this.props;
     return (
-      <RectButton
-        onPress={this.submit}
-        style={styles.resultItem}
-      >
+      <RectButton onPress={this.submit} style={styles.resultItem}>
         <Text style={styles.resultItemText}>{item}</Text>
       </RectButton>
     );
   }
 
   renderBlank() {
-    return (
-      <View style={styles.resultItem} />
-    );
-  };
+    return <View style={styles.resultItem} />;
+  }
 }


### PR DESCRIPTION
Also fixes the following issue:

- open search view, type query so that it matches second row in the list
- swipe open that row (reveal delete button)
- clear search query
- swipe on first row in the list
- result: two rows are both swiped open at the same time (first and second rows)

This was because the old approach was keeping track of the row index, but the index of the row changes when the list changes because of a search query. Now each row simply keeps track of whether it is open or closed, and if it's closed when the user tries to swipe on it, then it asks the parent to close any other open row.